### PR TITLE
Strict json response structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Since JSON responses may have very different formats, this package supports the 
 This package is an extension of the [HttpFoundation\JsonResponse](http://symfony.com/doc/current/components/http_foundation/introduction.html)
 class from the [Symfony](http://symfony.com/) package.
 
-[![Build Status](https://secure.travis-ci.org/gridonic/json-response?branch=master)](http://travis-ci.org/gridonic/json-response)
+[![Build Status](https://travis-ci.org/gridonic/JsonResponse.svg?branch=master)](https://travis-ci.org/gridonic/JsonResponse)
 
 ## Install
 

--- a/src/Gridonic/JsonResponse/ErrorJsonResponse.php
+++ b/src/Gridonic/JsonResponse/ErrorJsonResponse.php
@@ -21,15 +21,16 @@ class ErrorJsonResponse extends StructuredJsonResponse
      */
     public function __construct($data = null, $message = null, $status = 400, $headers = array(), $errorCode = null)
     {
+        // Make sure error json responses have error messages
+        if (!$message) {
+            throw new \InvalidArgumentException('An error json response must have an error message.');
+        }
+
         parent::__construct($data, $status, $headers);
 
         // Make sure error responses also have real error status codes
         if (!$this->isClientError() && !$this->isServerError()) {
             throw new \InvalidArgumentException(sprintf('The HTTP status code "%s" is not an error status code.', $status));
-        }
-
-        if (null === $data) {
-            $data = new \ArrayObject();
         }
 
         $this->setErrorCode($errorCode);
@@ -38,7 +39,7 @@ class ErrorJsonResponse extends StructuredJsonResponse
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public static function create($data = null, $message = null, $status = 400, $headers = array(), $errorCode = null)
     {
@@ -46,10 +47,22 @@ class ErrorJsonResponse extends StructuredJsonResponse
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getType()
     {
         return 'error';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function postProcessStructuredResponse(&$structuredResponse, $data)
+    {
+        parent::postProcessStructuredResponse($structuredResponse, $data);
+
+        if (empty($data) || ($data instanceof \ArrayObject && count($data) === 0)) {
+            unset($structuredResponse['data']);
+        }
     }
 }

--- a/src/Gridonic/JsonResponse/StructuredJsonResponse.php
+++ b/src/Gridonic/JsonResponse/StructuredJsonResponse.php
@@ -19,7 +19,6 @@ abstract class StructuredJsonResponse extends JsonResponse
 
     /**
      * @return string The type of the StructuredJsonResponse
-     *
      */
     abstract public function getType();
 
@@ -56,17 +55,29 @@ abstract class StructuredJsonResponse extends JsonResponse
         $structuredResponse = array(
             'status' => $this->getType(),
             'data' => $data,
-            'message' => $this->message
+            'message' => $this->message,
+            'error_code' => $this->errorCode
         );
 
-        if ($this->errorCode !== null) {
-            $structuredResponse['error_code'] = $this->errorCode;
-        }
+        // Post process data and unset variables where necessary
+        $this->postProcessStructuredResponse($structuredResponse, $data);
 
         // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
         $this->data = json_encode($structuredResponse, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 
         return $this->update();
+    }
+
+    /**
+     * @param array $structuredResponse
+     * @param array $data
+     * @return array
+     */
+    protected function postProcessStructuredResponse(&$structuredResponse, $data)
+    {
+        if (null === $this->errorCode) {
+            unset($structuredResponse['error_code']);
+        }
     }
 
     /**

--- a/src/Gridonic/JsonResponse/SuccessJsonResponse.php
+++ b/src/Gridonic/JsonResponse/SuccessJsonResponse.php
@@ -27,10 +27,6 @@ class SuccessJsonResponse extends StructuredJsonResponse
             throw new \InvalidArgumentException(sprintf('The HTTP status code "%s" is not a success status code.', $status));
         }
 
-        if (null === $data) {
-            $data = new \ArrayObject();
-        }
-
         $this->setMessage($message);
         $this->setData($data);
     }
@@ -41,6 +37,18 @@ class SuccessJsonResponse extends StructuredJsonResponse
     public static function create($data = null, $message = null, $status = 200, $headers = array())
     {
         return new static($data, $message, $status, $headers);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function postProcessStructuredResponse(&$structuredResponse, $data)
+    {
+        parent::postProcessStructuredResponse($structuredResponse, $data);
+
+        if (null === $this->message) {
+            unset($structuredResponse['message']);
+        }
     }
 
     /**

--- a/tests/Gridonic/JsonResponse/Tests/ErrorJsonResponseTest.php
+++ b/tests/Gridonic/JsonResponse/Tests/ErrorJsonResponseTest.php
@@ -3,6 +3,7 @@
 namespace Gridonic\JsonResponse\Tests;
 
 use Gridonic\JsonResponse\ErrorJsonResponse;
+use InvalidArgumentException;
 
 /**
  * ErrorJsonResponse tests
@@ -13,13 +14,51 @@ class ErrorJsonResponseTest extends \PHPUnit_Framework_TestCase
 {
     public function testInstance()
     {
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\JsonResponse', new ErrorJsonResponse());
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\JsonResponse', new ErrorJsonResponse(null, 'Error message'));
+    }
+
+    /**
+     * @dataProvider invalidMessageProvider
+     * @expectedException InvalidArgumentException
+     */
+    public function testEmptyMessageThrowsException($message)
+    {
+        new ErrorJsonResponse(null, $message);
     }
 
     public function testConstructorDefaultJsonObject()
     {
-        $response = new ErrorJsonResponse();
+        $response = new ErrorJsonResponse(null, 'Error message');
         $this->assertEquals(400, $response->getStatusCode());
-        $this->assertSame('{"status":"error","data":{},"message":null}', $response->getContent());
+        $this->assertSame('{"status":"error","message":"Error message"}', $response->getContent());
+    }
+
+    /**
+     * @dataProvider optionalParametersProvider
+     */
+    public function testOptionalParametersInResponse($data, $message, $status, $expected)
+    {
+        $response = new ErrorJsonResponse($data, $message, $status);
+        $this->assertSame($expected, $response->getContent());
+    }
+
+    public function invalidMessageProvider()
+    {
+        return array(
+            array(null),
+            array(false),
+            array(''),
+        );
+    }
+
+    public function optionalParametersProvider()
+    {
+        return array(
+            array('data', 'Error message', 400, '{"status":"error","data":"data","message":"Error message"}'),
+            array(array('data'), 'Error message', 400, '{"status":"error","data":["data"],"message":"Error message"}'),
+            array(array('posts' => array('id' => 1)), 'Error message', 400, '{"status":"error","data":{"posts":{"id":1}},"message":"Error message"}'),
+            array(null, 'Error message', 400, '{"status":"error","message":"Error message"}'),
+            array(array(), 'Error message', 400, '{"status":"error","message":"Error message"}'),
+        );
     }
 }

--- a/tests/Gridonic/JsonResponse/Tests/SuccessJsonResponseTest.php
+++ b/tests/Gridonic/JsonResponse/Tests/SuccessJsonResponseTest.php
@@ -20,6 +20,20 @@ class SuccessJsonResponseTest extends \PHPUnit_Framework_TestCase
     {
         $response = new SuccessJsonResponse();
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertSame('{"status":"success","data":{},"message":null}', $response->getContent());
+        $this->assertSame('{"status":"success","data":null}', $response->getContent());
+    }
+
+    public function testJsonObjectWithData()
+    {
+        $postData = array(
+            'post' => array(
+                'id' => 1,
+                'title' => 'A blog post',
+            )
+        );
+
+        $response = new SuccessJsonResponse($postData);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('{"status":"success","data":{"post":{"id":1,"title":"A blog post"}}}', $response->getContent());
     }
 }


### PR DESCRIPTION
@dschenk / @btemperli I made some structural changes to the error and success responses. To adhere more to the specification here: http://labs.omniti.com/labs/jsend. Especially the error response now has a mandatory ```message``` parameter. From my point of view, we had some inconsistencies in there as for which parameters are always present and which are optional. Was that on purpose that we did not stick to the proposed format from http://labs.omniti.com/labs/jsend? Care to take a look and tell me what you think?

I assume this will break things in ```1.0.x``` so we should probably increase the release number to ```1.1.x``` once ready.